### PR TITLE
Generalizations

### DIFF
--- a/roles/capistrano_setup/tasks/main.yml
+++ b/roles/capistrano_setup/tasks/main.yml
@@ -15,6 +15,7 @@
   authorized_key: user={{ capistrano_user }} key={{ item }} exclusive=no state=present
   with_items:
     - "{{ keys_to_add }}"
+  when: keys_to_add is defined
 
 - name: allow capistrano user to restart resque-pool
   template: src=resque-restart-users dest=/etc/sudoers.d/resque-restart-users validate='visudo -cf %s'

--- a/roles/ec2/meta/main.yml
+++ b/roles/ec2/meta/main.yml
@@ -1,0 +1,5 @@
+---
+# FILE: roles/ec2/meta/main.yml
+
+dependencies:
+  - { role: mount_opt, data_device: /dev/xvdf }

--- a/roles/ec2/tasks/ec2_housekeeping.yml
+++ b/roles/ec2/tasks/ec2_housekeeping.yml
@@ -1,9 +1,4 @@
 ---
-- name: format volume for /opt
-  filesystem: fstype=xfs dev=/dev/xvdf
-
-- name: mount volume at /opt
-  mount: name=/opt src=/dev/xvdf fstype=xfs state=mounted
 
 - name: install PPA for ec2-consistent-snapshot
   apt_repository: repo='ppa:alestic'

--- a/roles/ec2/tasks/ec2_ubuntu_user.yml
+++ b/roles/ec2/tasks/ec2_ubuntu_user.yml
@@ -1,0 +1,5 @@
+---
+- name: add keys for ubuntu user
+  authorized_key: user=ubuntu key={{ item }} exclusive=no state=present
+  with_items:
+    - "{{ keys_to_add }}"

--- a/roles/ec2/tasks/main.yml
+++ b/roles/ec2/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 - include: ec2_housekeeping.yml
 - include: ec2_crons.yml
+- include: ec2_ubuntu_user.yml

--- a/roles/hydra-stack/install/tasks/fedora.yml
+++ b/roles/hydra-stack/install/tasks/fedora.yml
@@ -1,7 +1,15 @@
 ---
+- name: set fedora version if absent
+  set_fact: fedora_version "4.1.0"
+  when: fedora_version is undefined
+  
+- name: fedora version to install {{ fedora_version }}
+  # Handy in cases where we're logging or watching the console
+  debug: msg="Set 'fedora_version' in your variables to install a different version of Fedora Commons"
+  
 - name: download fedora
   become: yes
-  get_url: url=http://repo1.maven.org/maven2/org/fcrepo/fcrepo-webapp/4.1.0/fcrepo-webapp-4.1.0.war owner={{ install_user }} group={{ install_group }} dest={{ install_path }}/fcrepo-webapp-4.1.0.war timeout=100
+  get_url: url=http://repo1.maven.org/maven2/org/fcrepo/fcrepo-webapp/{{ fedora_version }}/fcrepo-webapp-{{ fedora_version }}.war owner={{ install_user }} group={{ install_group }} dest={{ install_path }}/fcrepo-webapp-{{ fedora_version }}.war timeout=100
 
 - name: make fedora data dir
   file: owner=tomcat7 group=tomcat7 state=directory path=/opt/fedora-data
@@ -14,7 +22,7 @@
 
 - name: copy over fedora.war
   sudo: yes
-  command: cp {{ install_path }}/fcrepo-webapp-4.1.0.war /var/lib/tomcat7/webapps/fedora.war
+  command: cp {{ install_path }}/fcrepo-webapp-{{ fedora_version }}.war /var/lib/tomcat7/webapps/fedora.war
   when: fedora_war.stat.exists == False
 
 - name: create tomcat config and java options

--- a/roles/hydra-stack/install/templates/tomcat7.j2
+++ b/roles/hydra-stack/install/templates/tomcat7.j2
@@ -1,6 +1,6 @@
 # A backup of the original file with addition options is at /etc/default/tomcat7.bak
 TOMCAT7_USER=tomcat7
 TOMCAT7_GROUP=tomcat7
-JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
+JAVA_HOME={{ java_home | default( "/usr/lib/jvm/java-7-openjdk-amd64" ) }}
 JAVA_OPTS="-Dfcrepo.home=/opt/fedora-data -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseCompressedOops -XX:-UseLargePagesIndividualAllocation -XX:MaxPermSize=128M -Xms512m -Xmx4096m -Djava.util.logging.config.file=/etc/tomcat7/logging.properties -server"
 

--- a/roles/mount_opt/tasks/main.yml
+++ b/roles/mount_opt/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+# ROLE: mount_opt
+# roles/mount_opt/tasks/main.yml
+#
+# Allows a separate data drive for /opt to be defined in your playbook
+# the setting is optional, leave it out if you want to leave /opt in it's original location
+#
+# USAGE
+# In your playbook
+#   - { role: mount_opt, data_device: /dev/sdc } # replace 'data_device' with the device you would like /opt mounted on
+
+- name: data_device undefined warning
+  debug: msg="WARNING - mount_opt role included without 'data_device' set"
+  when: data_device is undefined
+
+- name: format volume for /opt
+  become: yes
+  filesystem: fstype=xfs dev={{ data_device }}
+  when: data_device is defined
+
+- name: mount volume at /opt
+  become: yes
+  mount: name=/opt src={{ data_device }} fstype=xfs state=mounted
+  when: data_device is defined

--- a/roles/openjdk1_8/tasks/main.yml
+++ b/roles/openjdk1_8/tasks/main.yml
@@ -1,0 +1,34 @@
+# roles/openjdk1_8 - installs OpenJDK 1.8 for Ubuntu 14.04.x releases
+---
+- name: ensure add-apt-repositories is present
+  # sudo apt-get install software-properties-common
+  become: yes
+  apt: name=software-properties-common state=present
+  
+- name: add openjdk ppa
+  # sudo add-apt-repositories ppa:openjdk-r/ppa
+  become: yes
+  apt_repository: repo='ppa:openjdk-r/ppa'
+  
+- name: update apt caches
+  # sudo apt-get update 
+  become: yes
+  apt: update_cache=yes
+
+- name: install openjdk 1.8
+  # sudo apt-get install openjdk-8-jdk
+  become: yes
+  apt: name=openjdk-8-jdk state=latest
+  
+- name: select correct java version
+  # sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+  become: yes
+  alternatives: name=java path=/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+
+- name: select correct java compiler version
+  # sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
+  become: yes
+  alternatives: name=javac path=/usr/lib/jvm/java-8-openjdk-amd64/bin/javac
+  
+- name: set java version for tomcat
+  set_fact: java_home=/usr/lib/jvm/java-8-openjdk-amd64

--- a/roles/system_setup/tasks/main.yml
+++ b/roles/system_setup/tasks/main.yml
@@ -10,9 +10,3 @@
 
 - name: create install directory
   file: owner={{ install_user }} group={{ install_group }} state=directory path=/opt/install
-
-# TODO: make this into a variable instead of hard-coding ubuntu user
-- name: add keys for ubuntu user
-  authorized_key: user=ubuntu key={{ item }} exclusive=no state=present
-  with_items:
-    - "{{ keys_to_add }}"

--- a/roles/vagrant_setup/tasks/main.yml
+++ b/roles/vagrant_setup/tasks/main.yml
@@ -1,0 +1,11 @@
+# ROLE: vagrant_setup
+# put any tasks here needed to make a vagrant VM look and behave consistently with 
+# a vanilla server or EC2 instance
+---
+- name: read vagrant public key
+  shell: grep vagrant .ssh/authorized_keys 
+  register: vagrant_public_key
+  
+- name: add vagrant public key to deloyment key list
+  set_fact:
+    keys_to_add: "{{ keys_to_add | default( [ ] ) + [ vagrant_public_key.stdout | quote ] }}"


### PR DESCRIPTION
Added functionality to cap-refactor to provide:
* Selectable fedora version for install - defaults to 4.1.0
* Moves the ubuntu key setup to EC2 since the 'ubuntu' user isn't created in vagrant or other vanilla Centos installs
* Gracefully proceeds if no keys_to_add are supplied or needed
* Add installer for for OpenJDK 1.8 if you're running Fedora 4.3.0 or above on Ubuntu 14.04.x LTS (which doesn't have Java 8 in core repos yet)
* Pulls the 'vagrant' user public key into the 'deploy' user so we can consistently use the 'deploy' user for cap scripts across all platforms
* Makes the target device for /opt drive mounting selectable